### PR TITLE
Fix internal error on getflag when putflag data missing

### DIFF
--- a/checker/src/checker.py
+++ b/checker/src/checker.py
@@ -133,7 +133,7 @@ class N0t3b00kChecker(BaseChecker):
                 username: str = self.chain_db["username"]
                 password: str = self.chain_db["password"]
                 noteId: str = self.chain_db["noteId"]
-            except IndexError as ex:
+            except Exception as ex:
                 self.debug(f"error getting notes from db: {ex}")
                 raise BrokenServiceException("Previous putflag failed.")
 


### PR DESCRIPTION
Could also just catch `KeyError` since that is the only one that seems to be thrown but the other code already present just catches `Exception` so I matched that.

See also [here](https://github.com/enowars/enowars5-service-stldoctor/issues/21). 