### PR TITLE
Add troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,62 @@ ENOCHECKER_TEST_CHECKER_ADDRESS='localhost' ENOCHECKER_TEST_CHECKER_PORT='8000' 
 # Questions?
 
 We understand that this can be a bit overwhelming at first, but you'll quickly get used to the workflow. Nonetheless, *please* reach out to us if you're having problems getting started or something is unclear.
+
+# Troubleshoot
+
+<details>
+
+<summary><b>Checker is not able to communicate with service</b></summary>
+
+**Note 1: The following configuration MUST be removed before the test runs and test-/ final-ctf.**
+
+**Note 2: Before applying the following configuration, check your firewall's INPUT rules.**
+
+If you are trying to reach the service from your checker, normally it should be possible by providing the ip address of your hostmachine (run `ip a` to find it): `enochecker_cli -A http://localhost:<CHECKER_PORT>/ -a <HOST_IP> putflag`. However on some machines this was not working as intended.
+
+Enabling all containers to communicate with each other is possible by creating a docker network:
+
+1. First, define a network within `service/docker-compose.yml` like so:
+
+```yaml
+service:
+  my-service-container: # this name will also be the DNS entry within the network
+    # ...
+    networks:
+      - my-network
+
+networks:
+  my-network:
+    driver: bridge
+```
+
+2. Start your service's compose without detach (no `-d`) and watch the stdout. It should be printed that the network was created. Copy the name of the network, it should be something like `service_my-network`.
+
+Reference: [Networking in Compose](https://docs.docker.com/compose/networking/)
+
+> Note
+> Your app's network is given a name based on the "project name", which is based on the name of the directory it lives in. You can override the project name with either the --project-name flag or the COMPOSE\_PROJECT\_NAME environment variable.
+
+3. Now, add the checker containers to the network within `checker/docker-compose.yml` like so:
+
+```yaml
+services:
+  my-service-checker:
+    # ...
+    networks:
+      - service_my-network
+  my-service-mongo:
+    # ...
+    networks:
+      - service_my-network
+
+networks:
+  service_my-network:
+    external: True 
+```
+
+4. Start your checkers compose.
+5. To test, you can attach to the checker's container: Find the name of the checker container by running `docker ps -a`. Now run `docker exec -it <CONTAINER_NAME> bash` and try to send a request to your service container: `curl http://my-service-container:<PORT>` (only works if you have an HTTP API exposed). If the `curl` call returns something, everything should be working now, congrats!
+6. From your host you can now use enochecker\_cli to run specific checker tasks like so: `enochecker_cli -A http://localhost:<CHECKER_PORT>/ -a my-service-container <TASK>`
+
+</details>


### PR DESCRIPTION
This PR adds a troubleshooting section to the README with one entry on how to enable checker+service communication with a Docker network.