### PR TITLE
Update checker python version and add restart unless-stopped

### DIFF
--- a/checker3/Dockerfile
+++ b/checker3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster
+FROM python:3.13-slim-bookworm
 RUN apt-get update && apt-get upgrade -y 
 
 # add checker user

--- a/checker3/docker-compose.yaml
+++ b/checker3/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   n0t3b00k-checker:
     build: .
+    restart: unless-stopped
     # The checker runs a HTTP interfaces, so we need to map port 3031 to the outside (port 8000).
     ports:
       - 12323:8000
@@ -22,6 +23,7 @@ services:
   # The python checkerlib requires a mongo db!
   n0t3b00k-mongo:
     image: mongo
+    restart: unless-stopped
     #ports:
     #  - 27017:27017
     volumes:

--- a/checker3/docker-compose.yaml
+++ b/checker3/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   n0t3b00k-checker:
     build: .


### PR DESCRIPTION
- Debian buster lts is not supported for over a year now
- attribute `version` is obsolete
- restart unless-stopped was missing