### PR TITLE
set checker mtu to 1420

### DIFF
--- a/checker3/docker-compose.yaml
+++ b/checker3/docker-compose.yaml
@@ -1,5 +1,11 @@
 version: '2.1'
 
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1420
+
 services:
   n0t3b00k-checker:
     build: .


### PR DESCRIPTION
Together with https://github.com/enowars/bambictf/pull/109 this fixes the issue that checker traffic is in some cases fingerprintable by looking at the TCP MSS